### PR TITLE
:bug: Accepts invalid domains

### DIFF
--- a/src/main/java/emailvalidator4j/lexer/EmailLexer.java
+++ b/src/main/java/emailvalidator4j/lexer/EmailLexer.java
@@ -16,7 +16,7 @@ public class EmailLexer {
 
     public void lex(String input) {
         Pattern pattern = Pattern.compile(
-                "([a-zA-Z_]+[46]?)|([0-9]+)|(\r\n)|(::)|(\\s+?)|(.)|(\\p{Cc}+)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE
+                "(([a-zA-Z_]|[^\\u0000-\\u007F])+[46]?)|([0-9]+)|(\r\n)|(::)|(\\s+?)|(.)|(\\p{Cc}+)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE
         );
         Matcher matcher = pattern.matcher(input);
 

--- a/src/main/java/emailvalidator4j/parser/DomainPart.java
+++ b/src/main/java/emailvalidator4j/parser/DomainPart.java
@@ -55,6 +55,10 @@ final class DomainPart extends Parser {
         int domainPartOpenedParenthesis = 0;
         boolean openBrackets = false;
         do {
+            if (this.lexer.getCurrent().equals(Tokens.HYPHEN)) {
+                throw new DomainHyphen("Found -  in domain part");
+            }
+
             if (this.lexer.getCurrent().equals(Tokens.SEMICOLON)) {
                 throw new ExpectedATEXT("Expected ATEXT");
             }
@@ -148,6 +152,11 @@ final class DomainPart extends Parser {
 
         if (this.lexer.getCurrent().equals(Tokens.BACKSLASH) && this.lexer.isNextToken(Tokens.get("GENERIC"))) {
             throw new ExpectedATEXT("Found BACKSLASH");
+        }
+
+        if (this.lexer.getCurrent().equals(Tokens.get("GENERIC")) && this.lexer.isNextToken(Tokens.get("GENERIC"))) {
+            this.lexer.next();
+            throw new ConsecutiveGeneric("Found " + this.lexer.getCurrent().getText());
         }
     }
 

--- a/src/main/java/emailvalidator4j/parser/exception/ConsecutiveGeneric.java
+++ b/src/main/java/emailvalidator4j/parser/exception/ConsecutiveGeneric.java
@@ -1,0 +1,7 @@
+package emailvalidator4j.parser.exception;
+
+public class ConsecutiveGeneric extends InvalidEmail {
+    public ConsecutiveGeneric(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/emailvalidator4j/parser/DomainPartTest.java
+++ b/src/test/java/emailvalidator4j/parser/DomainPartTest.java
@@ -47,10 +47,14 @@ public class DomainPartTest {
                 {ConsecutiveAT.class, "@@start"},
                 {ExpectedATEXT.class, "@at[start"},
                 {DomainHyphen.class, "@atstart-.com"},
+                {DomainHyphen.class, "@bb.-cc"},
+                {DomainHyphen.class, "@bb.-cc-"},
+                {DomainHyphen.class, "@bb.cc-"},
                 {DomainNotAllowedCharacter.class, "@atst\\art.com"},
                 {DomainNotAllowedCharacter.class, "@example\\"},
                 {DomainNotAllowedCharacter.class, "@exa\\mple"},
                 {UnclosedDomainLiteral.class, "@example]"},
+                {ConsecutiveGeneric.class, "@example'"},
         };
     }
 


### PR DESCRIPTION
 - Broaden GENERIC lexer regex to include non-ASCII for IDNs

 - Consider consecutive GENERIC tokens invalid in domain-part

 - Consider a leading hyphen in any part of a domain name an error

Fix cover tests cases from #2 as well.